### PR TITLE
feat: add Transaction History

### DIFF
--- a/stellar_agent/__init__.py
+++ b/stellar_agent/__init__.py
@@ -1,3 +1,7 @@
 """Stellar Agent - A CLI tool for Stellar blockchain payments."""
 
 __version__ = "0.1.0"
+
+from .history import TransactionHistory
+
+__all__ = ["TransactionHistory"]

--- a/stellar_agent/cli.py
+++ b/stellar_agent/cli.py
@@ -1,7 +1,51 @@
 """Command-line interface for Stellar Agent."""
 from .client import StellarClient
+from .history import TransactionHistory
 from .config import config
 from .utils.validators import is_valid_stellar_address, is_valid_amount
+
+def show_history():
+    """Interactive CLI for viewing Stellar transaction history."""
+    history = TransactionHistory()
+
+    account_id = input("Enter account public key to view history: ").strip()
+    if not is_valid_stellar_address(account_id):
+        print("❌ Invalid Stellar address. Must start with 'G' and be 56 characters long.")
+        return
+
+    limit_str = input("How many transactions to show? [default: 10]: ").strip()
+    try:
+        limit = int(limit_str) if limit_str else 10
+        if limit < 1:
+            raise ValueError
+    except ValueError:
+        print("❌ Invalid number. Using default of 10.")
+        limit = 10
+
+    print(f"\nFetching last {limit} transaction(s) for {account_id[:8]}…\n")
+    try:
+        result = history.get_formatted_history(account_id, limit=limit)
+    except RuntimeError as e:
+        print(f"❌ {e}")
+        return
+
+    if result["count"] == 0:
+        print("ℹ️  No payment history found for this account.")
+        return
+
+    print(f"{'#':<4} {'Date':<20} {'Dir':<10} {'Amount':<16} {'Asset':<12} {'Counterpart':<58} {'Tx Hash'}")
+    print("-" * 140)
+    for i, p in enumerate(result["payments"], start=1):
+        direction_icon = "⬇ IN " if p["direction"] == "RECEIVED" else "⬆ OUT"
+        print(
+            f"{i:<4} {p['created_at']:<20} {direction_icon:<10} "
+            f"{p['amount']:<16} {p['asset']:<12} "
+            f"{p['counterpart']:<58} {p['transaction_hash']}"
+        )
+
+    if result["next_cursor"]:
+        print(f"\n💡 Next cursor for pagination: {result['next_cursor']}")
+
 
 def prompt_and_send():
     """Interactive CLI for sending Stellar payments."""
@@ -17,10 +61,15 @@ def prompt_and_send():
     
     while True:
         print("\n--- Stellar Agent ---")
-        destination = input("Enter destination public key (or type 'exit' to quit): ").strip()
-        
+        print("Commands: send | history | exit")
+        destination = input("Enter destination public key (or 'history' / 'exit'): ").strip()
+
         if destination.lower() == "exit":
             break
+
+        if destination.lower() == "history":
+            show_history()
+            continue
         
         # Validate destination address
         if not is_valid_stellar_address(destination):
@@ -69,4 +118,8 @@ def prompt_and_send():
 
 def run():
     """Entry point for the CLI."""
-    prompt_and_send()
+    import sys
+    if len(sys.argv) > 1 and sys.argv[1] == "history":
+        show_history()
+    else:
+        prompt_and_send()

--- a/stellar_agent/history.py
+++ b/stellar_agent/history.py
@@ -1,0 +1,144 @@
+"""Transaction history module for Stellar Agent."""
+from stellar_sdk import Server
+from stellar_sdk.exceptions import NotFoundError
+from typing import Dict, Any, List, Optional
+from datetime import datetime
+from decimal import Decimal
+from .config import config
+
+
+class TransactionHistory:
+    """Fetches and formats Stellar account transaction history."""
+
+    def __init__(self):
+        self.server = Server(config.horizon_url)
+
+    def get_payments(
+        self,
+        account_id: str,
+        limit: int = 10,
+        cursor: Optional[str] = None,
+        order: str = "desc",
+    ) -> Dict[str, Any]:
+        """
+        Fetch payment operations for a given account.
+
+        Args:
+            account_id: Public key of the account
+            limit: Number of records to return (max 200)
+            cursor: Paging token for pagination
+            order: 'asc' or 'desc' (default: 'desc' = newest first)
+
+        Returns:
+            Dict with 'records' list and 'next_cursor' for pagination
+
+        Raises:
+            RuntimeError: If account not found or network issues occur
+        """
+        try:
+            limit = max(1, min(limit, 200))
+            builder = (
+                self.server.payments()
+                .for_account(account_id)
+                .order(order)
+                .limit(limit)
+            )
+            if cursor:
+                builder = builder.cursor(cursor)
+
+            response = builder.call()
+            records = response.get("_embedded", {}).get("records", [])
+            next_cursor = None
+            if records:
+                next_cursor = records[-1].get("paging_token")
+
+            return {
+                "records": records,
+                "next_cursor": next_cursor,
+                "count": len(records),
+            }
+        except NotFoundError:
+            raise RuntimeError(
+                f"Account {account_id} not found on the Stellar network."
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to fetch payment history: {e}")
+
+    def format_payment(self, record: Dict[str, Any], account_id: str) -> Dict[str, Any]:
+        """
+        Format a raw payment record into a human-readable dict.
+
+        Args:
+            record: Raw payment record from Horizon
+            account_id: The account whose perspective we use (to detect direction)
+
+        Returns:
+            Formatted payment dictionary
+        """
+        op_type = record.get("type", "unknown")
+
+        if op_type == "payment":
+            asset = (
+                "XLM"
+                if record.get("asset_type") == "native"
+                else f"{record.get('asset_code', '?')}/{record.get('asset_issuer', '')[:8]}…"
+            )
+            amount = record.get("amount", "0")
+            from_addr = record.get("from", "")
+            to_addr = record.get("to", "")
+            direction = "RECEIVED" if to_addr == account_id else "SENT"
+            counterpart = from_addr if direction == "RECEIVED" else to_addr
+        elif op_type == "create_account":
+            asset = "XLM"
+            amount = record.get("starting_balance", "0")
+            from_addr = record.get("funder", "")
+            to_addr = record.get("account", "")
+            direction = "RECEIVED" if to_addr == account_id else "SENT"
+            counterpart = from_addr if direction == "RECEIVED" else to_addr
+        else:
+            asset = "—"
+            amount = "—"
+            direction = "—"
+            counterpart = "—"
+
+        # Parse ISO8601 created_at
+        created_at_raw = record.get("created_at", "")
+        try:
+            created_at = datetime.strptime(created_at_raw, "%Y-%m-%dT%H:%M:%SZ").strftime(
+                "%Y-%m-%d %H:%M UTC"
+            )
+        except ValueError:
+            created_at = created_at_raw
+
+        return {
+            "id": record.get("id", ""),
+            "type": op_type,
+            "direction": direction,
+            "amount": amount,
+            "asset": asset,
+            "counterpart": counterpart,
+            "transaction_hash": record.get("transaction_hash", ""),
+            "paging_token": record.get("paging_token", ""),
+            "created_at": created_at,
+        }
+
+    def get_formatted_history(
+        self,
+        account_id: str,
+        limit: int = 10,
+        cursor: Optional[str] = None,
+        order: str = "desc",
+    ) -> Dict[str, Any]:
+        """
+        Fetch and format payment history for an account.
+
+        Returns:
+            Dict with 'payments' (list of formatted records), 'next_cursor', 'count'
+        """
+        raw = self.get_payments(account_id, limit=limit, cursor=cursor, order=order)
+        formatted = [self.format_payment(r, account_id) for r in raw["records"]]
+        return {
+            "payments": formatted,
+            "next_cursor": raw["next_cursor"],
+            "count": raw["count"],
+        }

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,316 @@
+"""Tests for TransactionHistory module."""
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from stellar_agent.history import TransactionHistory
+
+
+MOCK_ACCOUNT_ID = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+OTHER_ACCOUNT_ID = "GDQJUTQYK2MQX2VGDR2FYWLIYAQIEGXTQVTFEMGH0BELWGYNR4GJKSV"
+
+
+@pytest.fixture
+def mock_config():
+    with patch("stellar_agent.history.config") as mock_conf:
+        mock_conf.horizon_url = "https://horizon-testnet.stellar.org"
+        yield mock_conf
+
+
+@pytest.fixture
+def history_client(mock_config):
+    with patch("stellar_agent.history.Server"):
+        client = TransactionHistory()
+        return client
+
+
+# ---------------------------------------------------------------------------
+# get_payments
+# ---------------------------------------------------------------------------
+
+def test_get_payments_success(mock_config):
+    """get_payments returns formatted records and next_cursor."""
+    sample_records = [
+        {
+            "id": "op1",
+            "type": "payment",
+            "paging_token": "token_op1",
+            "from": OTHER_ACCOUNT_ID,
+            "to": MOCK_ACCOUNT_ID,
+            "asset_type": "native",
+            "amount": "10.0000000",
+            "transaction_hash": "abc123",
+            "created_at": "2026-03-01T12:00:00Z",
+        }
+    ]
+
+    with patch("stellar_agent.history.Server") as mock_server_class:
+        mock_server = mock_server_class.return_value
+        mock_payments_builder = MagicMock()
+        mock_server.payments.return_value = mock_payments_builder
+        mock_payments_builder.for_account.return_value = mock_payments_builder
+        mock_payments_builder.order.return_value = mock_payments_builder
+        mock_payments_builder.limit.return_value = mock_payments_builder
+        mock_payments_builder.call.return_value = {
+            "_embedded": {"records": sample_records}
+        }
+
+        client = TransactionHistory()
+        result = client.get_payments(MOCK_ACCOUNT_ID, limit=10)
+
+    assert result["count"] == 1
+    assert result["records"] == sample_records
+    assert result["next_cursor"] == "token_op1"
+
+
+def test_get_payments_not_found(mock_config):
+    """get_payments raises RuntimeError when account is not found."""
+    from stellar_sdk.exceptions import NotFoundError
+
+    with patch("stellar_agent.history.Server") as mock_server_class:
+        mock_server = mock_server_class.return_value
+        mock_payments_builder = MagicMock()
+        mock_server.payments.return_value = mock_payments_builder
+        mock_payments_builder.for_account.return_value = mock_payments_builder
+        mock_payments_builder.order.return_value = mock_payments_builder
+        mock_payments_builder.limit.return_value = mock_payments_builder
+        mock_payments_builder.call.side_effect = NotFoundError(Mock())
+
+        client = TransactionHistory()
+        with pytest.raises(RuntimeError, match="not found on the Stellar network"):
+            client.get_payments(MOCK_ACCOUNT_ID)
+
+
+def test_get_payments_network_error(mock_config):
+    """get_payments wraps unexpected errors in RuntimeError."""
+    with patch("stellar_agent.history.Server") as mock_server_class:
+        mock_server = mock_server_class.return_value
+        mock_payments_builder = MagicMock()
+        mock_server.payments.return_value = mock_payments_builder
+        mock_payments_builder.for_account.return_value = mock_payments_builder
+        mock_payments_builder.order.return_value = mock_payments_builder
+        mock_payments_builder.limit.return_value = mock_payments_builder
+        mock_payments_builder.call.side_effect = ConnectionError("timeout")
+
+        client = TransactionHistory()
+        with pytest.raises(RuntimeError, match="Failed to fetch payment history"):
+            client.get_payments(MOCK_ACCOUNT_ID)
+
+
+def test_get_payments_with_cursor(mock_config):
+    """get_payments passes the cursor to the builder."""
+    with patch("stellar_agent.history.Server") as mock_server_class:
+        mock_server = mock_server_class.return_value
+        mock_payments_builder = MagicMock()
+        mock_server.payments.return_value = mock_payments_builder
+        mock_payments_builder.for_account.return_value = mock_payments_builder
+        mock_payments_builder.order.return_value = mock_payments_builder
+        mock_payments_builder.limit.return_value = mock_payments_builder
+        mock_payments_builder.cursor.return_value = mock_payments_builder
+        mock_payments_builder.call.return_value = {"_embedded": {"records": []}}
+
+        client = TransactionHistory()
+        client.get_payments(MOCK_ACCOUNT_ID, cursor="some_cursor")
+
+        mock_payments_builder.cursor.assert_called_once_with("some_cursor")
+
+
+def test_get_payments_limit_clamped(mock_config):
+    """Limit values below 1 are clamped to 1; above 200 clamped to 200."""
+    with patch("stellar_agent.history.Server") as mock_server_class:
+        mock_server = mock_server_class.return_value
+        mock_payments_builder = MagicMock()
+        mock_server.payments.return_value = mock_payments_builder
+        mock_payments_builder.for_account.return_value = mock_payments_builder
+        mock_payments_builder.order.return_value = mock_payments_builder
+        mock_payments_builder.limit.return_value = mock_payments_builder
+        mock_payments_builder.call.return_value = {"_embedded": {"records": []}}
+
+        client = TransactionHistory()
+
+        client.get_payments(MOCK_ACCOUNT_ID, limit=0)
+        mock_payments_builder.limit.assert_called_with(1)
+
+        client.get_payments(MOCK_ACCOUNT_ID, limit=999)
+        mock_payments_builder.limit.assert_called_with(200)
+
+
+# ---------------------------------------------------------------------------
+# format_payment
+# ---------------------------------------------------------------------------
+
+def test_format_payment_received_xlm(history_client):
+    """Incoming XLM payment is formatted correctly."""
+    record = {
+        "id": "op1",
+        "type": "payment",
+        "paging_token": "token_op1",
+        "from": OTHER_ACCOUNT_ID,
+        "to": MOCK_ACCOUNT_ID,
+        "asset_type": "native",
+        "amount": "25.5000000",
+        "transaction_hash": "hash_abc",
+        "created_at": "2026-03-01T10:00:00Z",
+    }
+
+    result = history_client.format_payment(record, MOCK_ACCOUNT_ID)
+
+    assert result["direction"] == "RECEIVED"
+    assert result["amount"] == "25.5000000"
+    assert result["asset"] == "XLM"
+    assert result["counterpart"] == OTHER_ACCOUNT_ID
+    assert result["created_at"] == "2026-03-01 10:00 UTC"
+
+
+def test_format_payment_sent_xlm(history_client):
+    """Outgoing XLM payment is formatted correctly."""
+    record = {
+        "id": "op2",
+        "type": "payment",
+        "paging_token": "token_op2",
+        "from": MOCK_ACCOUNT_ID,
+        "to": OTHER_ACCOUNT_ID,
+        "asset_type": "native",
+        "amount": "5.0000000",
+        "transaction_hash": "hash_def",
+        "created_at": "2026-03-02T15:30:00Z",
+    }
+
+    result = history_client.format_payment(record, MOCK_ACCOUNT_ID)
+
+    assert result["direction"] == "SENT"
+    assert result["counterpart"] == OTHER_ACCOUNT_ID
+    assert result["asset"] == "XLM"
+
+
+def test_format_payment_non_native_asset(history_client):
+    """Non-native asset is formatted with code and truncated issuer."""
+    record = {
+        "id": "op3",
+        "type": "payment",
+        "paging_token": "token_op3",
+        "from": OTHER_ACCOUNT_ID,
+        "to": MOCK_ACCOUNT_ID,
+        "asset_type": "credit_alphanum4",
+        "asset_code": "USDC",
+        "asset_issuer": "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+        "amount": "100.0000000",
+        "transaction_hash": "hash_ghi",
+        "created_at": "2026-03-03T08:00:00Z",
+    }
+
+    result = history_client.format_payment(record, MOCK_ACCOUNT_ID)
+
+    assert result["asset"].startswith("USDC/")
+    assert result["direction"] == "RECEIVED"
+
+
+def test_format_payment_create_account(history_client):
+    """create_account operation is formatted correctly."""
+    record = {
+        "id": "op4",
+        "type": "create_account",
+        "paging_token": "token_op4",
+        "funder": OTHER_ACCOUNT_ID,
+        "account": MOCK_ACCOUNT_ID,
+        "starting_balance": "1.0000000",
+        "transaction_hash": "hash_jkl",
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+
+    result = history_client.format_payment(record, MOCK_ACCOUNT_ID)
+
+    assert result["direction"] == "RECEIVED"
+    assert result["amount"] == "1.0000000"
+    assert result["type"] == "create_account"
+
+
+def test_format_payment_unknown_type(history_client):
+    """Unknown operation types are handled without crashing."""
+    record = {
+        "id": "op5",
+        "type": "change_trust",
+        "paging_token": "token_op5",
+        "transaction_hash": "hash_mno",
+        "created_at": "2026-03-04T12:00:00Z",
+    }
+
+    result = history_client.format_payment(record, MOCK_ACCOUNT_ID)
+
+    assert result["direction"] == "—"
+    assert result["asset"] == "—"
+
+
+def test_format_payment_invalid_date(history_client):
+    """Malformed created_at is returned as-is without raising."""
+    record = {
+        "id": "op6",
+        "type": "payment",
+        "from": OTHER_ACCOUNT_ID,
+        "to": MOCK_ACCOUNT_ID,
+        "asset_type": "native",
+        "amount": "1.0",
+        "transaction_hash": "hash_pqr",
+        "created_at": "not-a-date",
+        "paging_token": "tok",
+    }
+
+    result = history_client.format_payment(record, MOCK_ACCOUNT_ID)
+    assert result["created_at"] == "not-a-date"
+
+
+# ---------------------------------------------------------------------------
+# get_formatted_history
+# ---------------------------------------------------------------------------
+
+def test_get_formatted_history_empty(mock_config):
+    """get_formatted_history returns empty list when no payments found."""
+    with patch("stellar_agent.history.Server") as mock_server_class:
+        mock_server = mock_server_class.return_value
+        mock_payments_builder = MagicMock()
+        mock_server.payments.return_value = mock_payments_builder
+        mock_payments_builder.for_account.return_value = mock_payments_builder
+        mock_payments_builder.order.return_value = mock_payments_builder
+        mock_payments_builder.limit.return_value = mock_payments_builder
+        mock_payments_builder.call.return_value = {"_embedded": {"records": []}}
+
+        client = TransactionHistory()
+        result = client.get_formatted_history(MOCK_ACCOUNT_ID)
+
+    assert result["payments"] == []
+    assert result["count"] == 0
+    assert result["next_cursor"] is None
+
+
+def test_get_formatted_history_multiple(mock_config):
+    """get_formatted_history formats all records returned."""
+    records = [
+        {
+            "id": f"op{i}",
+            "type": "payment",
+            "paging_token": f"tok{i}",
+            "from": OTHER_ACCOUNT_ID,
+            "to": MOCK_ACCOUNT_ID,
+            "asset_type": "native",
+            "amount": f"{i}.0",
+            "transaction_hash": f"hash{i}",
+            "created_at": "2026-03-01T12:00:00Z",
+        }
+        for i in range(1, 4)
+    ]
+
+    with patch("stellar_agent.history.Server") as mock_server_class:
+        mock_server = mock_server_class.return_value
+        mock_payments_builder = MagicMock()
+        mock_server.payments.return_value = mock_payments_builder
+        mock_payments_builder.for_account.return_value = mock_payments_builder
+        mock_payments_builder.order.return_value = mock_payments_builder
+        mock_payments_builder.limit.return_value = mock_payments_builder
+        mock_payments_builder.call.return_value = {"_embedded": {"records": records}}
+
+        client = TransactionHistory()
+        result = client.get_formatted_history(MOCK_ACCOUNT_ID, limit=3)
+
+    assert result["count"] == 3
+    assert len(result["payments"]) == 3
+    for p in result["payments"]:
+        assert p["direction"] == "RECEIVED"
+        assert p["asset"] == "XLM"


### PR DESCRIPTION
- Add stellar_agent/history.py with TransactionHistory class
  - get_payments(): fetch payment operations from Horizon with pagination support
  - format_payment(): normalise raw records (direction, asset, date)
  - get_formatted_history(): convenience wrapper returning formatted list
- Update stellar_agent/cli.py
  - show_history() interactive command to display a paginated payment table
  - Main menu now accepts 'history' as an inline command
  - CLI entry-point routes 'stellar-agent history' to show_history()
- Export TransactionHistory from stellar_agent/__init__.py
- Add tests/test_history.py with 13 unit tests (all passing)